### PR TITLE
Issue-#6: Destroy method of process streamer should always shutdown

### DIFF
--- a/src/main/java/com/github/dakusui/processstreamer/core/process/ProcessStreamer.java
+++ b/src/main/java/com/github/dakusui/processstreamer/core/process/ProcessStreamer.java
@@ -150,8 +150,8 @@ public class ProcessStreamer {
 
   public void destroy() {
     synchronized (this.process) {
+      this.threadPool.shutdownNow();
       if (this.process.isAlive()) {
-        this.threadPool.shutdownNow();
         this.process.destroy();
       }
     }


### PR DESCRIPTION
 ```destroy``` method of ```ProcessStreamer``` should always shutdown the threadpool.